### PR TITLE
Fix window positioning on multi-monitor setups

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,8 +54,8 @@ export default class PerfectFitExtension extends Extension {
 
           window.move_resize_frame(
             true,
-            Math.floor((monitorGeometry.width - newWindowWidth) / 2),
-            Math.floor((monitorGeometry.height - newWindowHeight + Main.panel.height) / 2),
+            monitorGeometry.x + Math.floor((monitorGeometry.width - newWindowWidth) / 2),
+            monitorGeometry.y + Math.floor((monitorGeometry.height - newWindowHeight + Main.panel.height) / 2),
             newWindowWidth,
             newWindowHeight
           );
@@ -81,8 +81,8 @@ export default class PerfectFitExtension extends Extension {
 
           window.move_frame(
             true,
-            Math.floor((monitorGeometry.width - windowRect.width) / 2),
-            Math.floor((monitorGeometry.height - windowRect.height + Main.panel.height) / 2),
+            monitorGeometry.x + Math.floor((monitorGeometry.width - windowRect.width) / 2),
+            monitorGeometry.y + Math.floor((monitorGeometry.height - windowRect.height + Main.panel.height) / 2),
           );
         }
       }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,5 +5,5 @@
   "url": "https://github.com/yawuxi/perfect-fit",
   "settings-schema": "org.gnome.shell.extensions.perfect-fit",
   "gettext-domain": "perfect-fit",
-  "shell-version": ["48"]
+  "shell-version": ["48", "49"]
 }


### PR DESCRIPTION
Add monitorGeometry.x and monitorGeometry.y offsets to window positioning calculations. Without these offsets, windows are positioned relative to the primary monitor origin (0,0) instead of the target monitor's origin, causing incorrect placement on secondary monitors.

Also adds GNOME 49 to supported shell versions.